### PR TITLE
fix: type errors and console errors

### DIFF
--- a/components/screens/meta-screen.tsx
+++ b/components/screens/meta-screen.tsx
@@ -17,7 +17,6 @@ import {
   VolumeX,
   X,
 } from "lucide-react";
-import Image from "next/image";
 import { durationToText } from "@/lib/utils";
 import { create } from "zustand";
 import { Skeleton } from "@/components/ui/skeleton";
@@ -279,7 +278,7 @@ export const MetaScreen: FC = () => {
                       controls={false}
                       width="100%"
                       height="100%"
-                      autoplay={true}
+                      autoPlay
                       playing={playing}
                       volume={MetaScreenPlayerMuted ? 0 : 0.5}
                       muted={MetaScreenPlayerMuted}
@@ -646,7 +645,7 @@ export const MetaScreen: FC = () => {
                           </div>
                         </button>
                         <div className="grid gap-4 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
-                          {hub.Metadata.slice(0, 15).map((item, i) => (
+                          {hub.Metadata?.slice(0, 15).map((item, i) => (
                             <VideoView
                               key={i}
                               item={{

--- a/plex.d.ts
+++ b/plex.d.ts
@@ -470,7 +470,7 @@ declare namespace Plex {
     size: number;
     more: boolean;
     style: string;
-    Metadata: {
+    Metadata?: {
       ratingKey: string;
       key: string;
       guid: string;


### PR DESCRIPTION
<!--
Thank you for contributing to Plexy!
Please follow this template to ensure your pull request is reviewed promptly and thoroughly.
-->

## Description
This adds some super small fixes of things that went wrong when clicking around the UI:
- A reference error crash when trying to access the Metadata property from the hub object. It doesn't exist in that scenario (it happened when accessing the details page of an artist from a music library), so I updated the interface and added optional chaining to the implementation.
- `autoplay` was changed to `autoPlay` to match React naming and resolve console errors.

<!--
Provide a clear and concise description of the changes made in this pull request.
Include any relevant context or background information.
-->

## Type of Changes

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update (changes to README or other documentation)

## Checklist

Please ensure your pull request meets the following requirements:

- [x] Documentation has been updated to reflect changes (if applicable).
- [x] All dependencies have been updated in `package.json` & `pnpm-lock.yaml` (if applicable).
- [x] The application builds and runs without errors locally.
- [x] UI components use **ShadCN** components and follow the design.

## Testing

<!--
Describe how the changes have been tested. Provide steps for reviewers to verify your changes.
-->

## Screenshots

If applicable, include screenshots of the new feature, UI changes, or bug fixes:

<img width="550" alt="image" src="https://github.com/user-attachments/assets/0d239d2b-6225-450b-921d-bf63ea2fc5b1" />

<img width="1840" alt="image" src="https://github.com/user-attachments/assets/6fe9eb72-c80e-4db0-bb16-9ba1df407753" />

<!--
Thank you for your contribution!
Please ensure your pull request follows the template to streamline the review process.
-->