### PR TITLE
Fix issue #16 (error on ending of last show episode)

### DIFF
--- a/components/screens/watch-screen.tsx
+++ b/components/screens/watch-screen.tsx
@@ -484,6 +484,7 @@ export const WatchScreen: FC<{ watch: string | undefined }> = ({ watch }) => {
                     })}`,
                     { scroll: false },
                   );
+                  return;
                 }
 
                 router.replace(`${pathname}?watch=${next.ratingKey}`, {


### PR DESCRIPTION
## Description
issues when last episode of show was ending and the next routing was still being triggered.

## Type of Changes

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update (changes to README or other documentation)

## Related Issues

Link to any existing GitHub issues related to this pull request:
- Resolves #16 
- Related to #16

## Checklist

Please ensure your pull request meets the following requirements:

- [ ] Documentation has been updated to reflect changes (if applicable).
- [ ] All dependencies have been updated in `package.json` & `pnpm-lock.yaml` (if applicable).
- [x] The application builds and runs without errors locally.

## Testing

tested manually, waited for the end of the last episode of one of my shows and then closed the watched screen with no error.
I tried it multiple times to be sure
