### PR TITLE
feat: updated the carousel to display in aspect-video the clip type hub

### DIFF
--- a/app/browse/[key]/page.tsx
+++ b/app/browse/[key]/page.tsx
@@ -132,7 +132,9 @@ export default function Page() {
                 "lg:-mt-[calc(10vw-4rem)] md:mt-[3rem] -mt-[calc(-10vw-2rem)]",
             )}
             style={{
-              paddingTop: !featured ? APPBAR_HEIGHT : undefined,
+              paddingTop: !featured
+                ? `calc(${APPBAR_HEIGHT} + 2rem)`
+                : undefined,
             }}
           >
             {hubs &&
@@ -149,7 +151,7 @@ export default function Page() {
               ))}
           </div>
         </div>
-        <div className="absolute right-0 top-16 p-4">
+        <div className="absolute right-0 top-16 p-4 z-40">
           <Button
             type="button"
             variant="search"

--- a/components/hub-slider.tsx
+++ b/components/hub-slider.tsx
@@ -191,7 +191,8 @@ export const isOnDeckHub = (hub: Plex.Hub) => {
   const isInProgress = hub.context.includes("inprogress");
   const isContinueWatching = hub.context.includes("continueWatching");
   const isEpisodeType = hub.type === "episode";
-  return isInProgress || isContinueWatching || isEpisodeType;
+  const isClipType = hub.type === "clip";
+  return isInProgress || isContinueWatching || isEpisodeType || isClipType;
 };
 
 // TODO: have the HubSlider only receive the hub key and then let him deal with the items and fetching

--- a/plex.d.ts
+++ b/plex.d.ts
@@ -61,7 +61,8 @@ declare namespace Plex {
     | "track"
     | "season"
     | "album"
-    | "collection";
+    | "collection"
+    | "clip";
 
   interface LibrarySection {
     allowSync: boolean;


### PR DESCRIPTION
<!--
Thank you for contributing to Plexy!
Please follow this template to ensure your pull request is reviewed promptly and thoroughly.
-->

## Description

- Fixed issue with the library button being under the hub header for video library
- Updated the carousel ui for any clip hub to be in aspect video instead of poster


## Type of Changes

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update (changes to README or other documentation)

## Checklist

Please ensure your pull request meets the following requirements:

- [ ] Documentation has been updated to reflect changes (if applicable).
- [ ] All dependencies have been updated in `package.json` & `pnpm-lock.yaml` (if applicable).
- [x] The application builds and runs without errors locally.
- [x] UI components use **ShadCN** components and follow the design.

## Testing

manual testing was done

