### PR TITLE
feat: removed the rings on the buttons when focused in the watch screen

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -87,6 +87,10 @@
     body {
         @apply bg-background text-foreground;
     }
+
+    .without-ring {
+        @apply focus:ring-0 focus:ring-offset-0 focus-within:ring-0 focus-within:ring-offset-0 focus-visible:ring-0 focus-visible:ring-offset-0 ring-0 ring-offset-0 focus:outline-0 focus-within:outline-0 focus-visible:outline-0 outline-0 focus:border-0 focus-within:border-0 focus-visible:border-0 border-0;
+    }
 }
 
 .hover-time {

--- a/components/screens/watch-screen.tsx
+++ b/components/screens/watch-screen.tsx
@@ -557,7 +557,7 @@ export const WatchScreen: FC<{ watch: string | undefined }> = ({ watch }) => {
           >
             <button
               onClick={() => back()}
-              className="group w-fit"
+              className="group w-fit without-ring"
               id="button-back"
               onKeyDown={(event) => {
                 if (event.key === " ") {
@@ -653,6 +653,7 @@ export const WatchScreen: FC<{ watch: string | undefined }> = ({ watch }) => {
             >
               <button
                 id="button-play"
+                className="without-ring"
                 onKeyDown={(event) => {
                   if (event.key === " ") {
                     event.preventDefault();
@@ -677,6 +678,7 @@ export const WatchScreen: FC<{ watch: string | undefined }> = ({ watch }) => {
               <div className="flex group items-center">
                 <button
                   id="button-volume"
+                  className="without-ring"
                   onKeyDown={(event) => {
                     if (event.key === " ") {
                       event.preventDefault();
@@ -722,6 +724,7 @@ export const WatchScreen: FC<{ watch: string | undefined }> = ({ watch }) => {
                   <span>
                     <button
                       id="button-grandparent"
+                      className="without-ring"
                       onKeyDown={(event) => {
                         if (event.key === " ") {
                           event.preventDefault();
@@ -739,6 +742,7 @@ export const WatchScreen: FC<{ watch: string | undefined }> = ({ watch }) => {
                     {" - "}
                     <button
                       id="button-parent"
+                      className="without-ring"
                       onKeyDown={(event) => {
                         if (event.key === " ") {
                           event.preventDefault();
@@ -765,6 +769,7 @@ export const WatchScreen: FC<{ watch: string | undefined }> = ({ watch }) => {
                   <Tooltip>
                     <TooltipTrigger asChild id="button-next">
                       <button
+                        className="without-ring"
                         onKeyDown={(event) => {
                           if (event.key === " ") {
                             event.preventDefault();
@@ -812,6 +817,7 @@ export const WatchScreen: FC<{ watch: string | undefined }> = ({ watch }) => {
               <Dialog>
                 <DialogTrigger asChild>
                   <button
+                    className="without-ring"
                     onKeyDown={(event) => {
                       if (event.key === " ") {
                         event.preventDefault();
@@ -1008,6 +1014,7 @@ export const WatchScreen: FC<{ watch: string | undefined }> = ({ watch }) => {
                 </DialogContent>
               </Dialog>
               <button
+                className="without-ring"
                 onKeyDown={(event) => {
                   if (event.key === " ") {
                     event.preventDefault();


### PR DESCRIPTION
## Description

This was bugging me for a bit now. Basically when clicking on a button in the watch screen, let's say the playback setting button, and then pressing the spacebar to pause/play the video it would show a ring around the button that was previously pressed.

## Type of Changes

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update (changes to README or other documentation)

## Related Issues

Link to any existing GitHub issues related to this pull request:
- Resolves #<issue_number>
- Related to #<issue_number>

## Checklist

Please ensure your pull request meets the following requirements:

- [x] Documentation has been updated to reflect changes (if applicable).
- [x] All dependencies have been updated in `package.json` & `pnpm-lock.yaml` (if applicable).
- [x] The application builds and runs without errors locally.
- [x] UI components use **ShadCN** components and follow the design.

## Testing

Manually tested

## Additional Notes

Add any additional comments, caveats, or information here:
> This was more of a personal change and it might not follow the "good" standards for the web, but it was frustrating me, so i did ended up changing it.